### PR TITLE
fix(ci): Should specify language for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
+sudo: false
+language: node_js
 notifications:
   email:
     - dengfuping_develop@163.com
 node_js:
-  - 9
+  - 10
 script:
   - npm run lint
 deploy:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "start": "umi dev",
     "build": "umi build",
     "test": "umi test",
-    "lint": "eslint --ext .js src mock tests",
+    "lint": "eslint --ext .js src",
     "precommit": "lint-staged"
   },
   "dependencies": {


### PR DESCRIPTION
- 没有指定语言，`Travis CI` 默认使用 `Ruby Gem` 安装依赖。对于 JS 应用，需要手动指定 `language` 为 `node_js`。
- 构建错误日志: https://travis-ci.org/dengfuping/hasantvpassedechartsyet/builds/569943109
![image](https://user-images.githubusercontent.com/14918822/62798494-f5401800-bb10-11e9-9f06-1032b9f8217e.png)
