### PR TITLE
fix(ci): Remove project config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ script:
   - npm run lint
 deploy:
   provider: surge
-  project: ./dist/
   skip_cleanup: true
   domain: hasantvpassedechartsyet.surge.sh
   on:


### PR DESCRIPTION
- 项目目录和仓库根目录一致时，不需要配置 `project`，参考 https://docs.travis-ci.com/user/deployment/surge/#configuration-of-travisyml。
![image](https://user-images.githubusercontent.com/14918822/62799959-b744f300-bb14-11e9-96da-84855d06139b.png)
